### PR TITLE
Confirmation page set up, linking to dashboard from confirmation page

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   // Service name used in header. Eg: 'Renew your passport'
-  serviceName: 'Service name goes here',
+  serviceName: 'Manage your inspections',
 
   // Default port that prototype runs on
   port: '3000',

--- a/app/routes.js
+++ b/app/routes.js
@@ -33,7 +33,7 @@ router.post('/lead-inspector/upload-planning-document', function (req, res) {
 
   // This is the URL the users will be redirected to once the email
   // has been sent
-  res.redirect('12345?planningDocUploaded=true');
+  res.redirect('Confirmation');
 
 });
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -33,7 +33,7 @@ router.post('/lead-inspector/upload-planning-document', function (req, res) {
 
   // This is the URL the users will be redirected to once the email
   // has been sent
-  res.redirect('Confirmation');
+  res.redirect('confirmation');
 
 });
 

--- a/app/views/lead-inspector/12345.html
+++ b/app/views/lead-inspector/12345.html
@@ -93,14 +93,16 @@
           </li>
         {% endif %}
         <li>
-          <a class="govuk-link" href="#">Fusce Dolor Nibh Ipsum Ornare</a>
+          <a class="govuk-link" href="https://drive.google.com/open?id=1KfnHBofwh-rIDfk-G_MlsTOPdt7wlLtE">Prompts for the phone call with the provider</a>
         </li>
         <li>
-          <a class="govuk-link" href="#">Magna Adipiscing Dapibus Commodo</a>
+          <a class="govuk-link" href="https://drive.google.com/open?id=17nIvjB-No3mcq92vEPxRD_uRR_Vspcxl">Guidance on how to select a sample of trainees to observe</a>
         </li>
         <li>
-          <a class="govuk-link" href="#">Venenatis Elit Ligula</a>
+          <a class="govuk-link" href="https://drive.google.com/open?id=1DxEY_yvWjqVeYkoomEY3JR2ZDx2pnAbZ">Joining instructions and team briefing</a>
         </li>
+        <li>
+          <a class="govuk-link" href="https://ofsted365.sharepoint.com/sites/IN0126/Data Acquisition and Planning/Forms/AllItems.aspx?id=%2Fsites%2FIN0126%2FData%20Acquisition%20and%20Planning%2FPlanning%2FNCTL%20Evaluation%20Reports">DfE 2016-2017 Master Evaluation Report (via Sharepoint)</a>
       </ul>
     </div>
 

--- a/app/views/lead-inspector/12345.html
+++ b/app/views/lead-inspector/12345.html
@@ -17,7 +17,7 @@
 
       <form action="confirm-planning-call" method="post" class="form">
         {{ govukButton({
-          text: "Begin the workflow for inspection 12345"
+          text: "Start the pre-inspection workflow"
         }) }}
       </form>
     </div>
@@ -81,6 +81,7 @@
       </dl>
 
     </div>
+
 
     <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m">Pre-inspection materials</h2>

--- a/app/views/lead-inspector/confirmation.html
+++ b/app/views/lead-inspector/confirmation.html
@@ -22,11 +22,7 @@
 
       <h2 class="govuk-heading-m">What happens next</h2>
       <p>We will email you once the ITE partnership uploads their pre-inspection documents.</p>
-      <form action="dashboard" method="post" class="form">
-        {{ govukButton({
-          text: "Return to your inspections dashboard"
-        }) }}
-      </form>
+      <p><a href="12345?planningDocUploaded=true" class="govuk-link">Return to the inspection page for Consortium2</a><p>
       <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a> (takes 30 seconds)</p>
 
 

--- a/app/views/lead-inspector/confirmation.html
+++ b/app/views/lead-inspector/confirmation.html
@@ -1,0 +1,31 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Confirmation page example
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="govuk-panel govuk-panel--confirmation">
+        <h1 class="govuk-panel__title">Pre-inspection workflow completed</h1>
+        <div class="govuk-panel__body">
+          We've emailed your planning document to the provider
+        </div>
+      </div>
+
+      <p>
+        We have sent you a copy of that email.
+      </p>
+
+      <h2 class="govuk-heading-m">What happens next</h2>
+      <p>We will email you once the ITE partnership uploads their pre-inspection documents.</p>
+      <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a> (takes 30 seconds)</p>
+
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/lead-inspector/confirmation.html
+++ b/app/views/lead-inspector/confirmation.html
@@ -22,6 +22,11 @@
 
       <h2 class="govuk-heading-m">What happens next</h2>
       <p>We will email you once the ITE partnership uploads their pre-inspection documents.</p>
+      <form action="dashboard" method="post" class="form">
+        {{ govukButton({
+          text: "Return to your inspections dashboard"
+        }) }}
+      </form>
       <p><a href="https://www.gov.uk/service-manual/user-centred-design/resources/patterns/feedback-pages.html">What did you think of this service?</a> (takes 30 seconds)</p>
 
 

--- a/app/views/lead-inspector/upload-planning-document.html
+++ b/app/views/lead-inspector/upload-planning-document.html
@@ -22,9 +22,11 @@
           id: "planning-doc-upload",
           name: "planning-doc-upload",
           label: {
-            text: "Upload your document"
+            text: ""
           }
         }) }}
+
+        <p>The document you are uploading will be sent to the ITE partnership.<p>
 
         {{ govukButton({
           text: "Upload your document"


### PR DESCRIPTION
Following changes:

1. confirmation page created and linked to upload planning document
2. button added to go back to the dashboard from confirmation page
3. by doing nr 2 above, the user can no longer see the updated pre-inspection materials list with the "Lead Inspector's planning document". I need to speak to Gaz about that... 