### PR TITLE
Feature/62-add-the-official-title-of-the-responsible-person

### DIFF
--- a/app/views/lead-inspector/12345.html
+++ b/app/views/lead-inspector/12345.html
@@ -85,7 +85,7 @@
           Responsible person
         </dt>
         <dd class="govuk-summary-list__value">
-          Isabella Mora
+          Isabella Mora, Programme Leader
         </dd>
       </div>
         <div class="govuk-summary-list__row">


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/foUhSieR/62-add-the-official-title-of-the-responsible-person

## Changes in this PR:
Updating the "responsible persons detail" the name of that person and indicated their role a headteacher, of example.

## Screenshots of UI changes:
<img width="853" alt="Screenshot 2020-02-11 at 09 26 36" src="https://user-images.githubusercontent.com/10596845/74224373-a0907c00-4cb0-11ea-9787-bad9b185ac03.png">
