### PR TITLE
Feature/63 leads inspector call to ite partnership page improvements Front end

### DIFF
--- a/app/views/lead-inspector/confirm-planning-call.html
+++ b/app/views/lead-inspector/confirm-planning-call.html
@@ -62,7 +62,8 @@
             </h2>
           </div>
           <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
-            <p class='govuk-body'>After the ISA notifies the partnership about the upcoming inspection, it is the Lead Inspector's duty to hold a planning call with them. There are two things you need to go through with the partnership:</p>
+            <p class='govuk-body'>After the ISA notifies the partnership about the upcoming inspection, it is the Lead Inspector's duty to hold a planning call with them. There are two areas  you need to discuss  with the partnership:
+            </p>
             <ul class="govuk-list govuk-list--bullet">
               <li>education focused conversation</li>
               <li>inspection planning conversation</li>
@@ -73,15 +74,16 @@
           <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
               <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
-                1. Inspection planning discussion
+                1. The inspection process
               </span>
             </h2>
           </div>
           <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
-            <p class='govuk-body'>On the call, you will review details of trainees’ placements or place of work, including addresses and unique reference numbers (URNs) for schools, colleges and/or settings. This is also your chance to discuss trainee visits and meetings to support exploration of the training course. </p>
+            <p class='govuk-body'>During  the phone call, you will review:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>text</li>
-              <li>text</li>
+              <li>details of trainees’ placements or place of work, including addresses and unique reference numbers (URNs) for schools, colleges or other settings
+              <a href="#">Dummy link</a></li>
+              <li>discuss meeting with trainees currently on the training course.</li>
             </ul>
           </div>
         </div>
@@ -89,19 +91,25 @@
           <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
               <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-                2. Educationally focused conversation
+                2. The education environment
               </span>
             </h2>
           </div>
           <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-            <p class='govuk-body'>As Lead Inspector, you need to understand the partnership’s context, and assess the progress it has made since the previous inspection, including assessment of its current strengths and weaknesses, and any specific progress made on areas for improvement identified at previous inspections that remain relevant under the current inspection framework.</p>
+            <p class='govuk-body'>As Lead Inspector, you need to understand:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>The partnership’s context</li>
+              <li>the progress it has made since the previous inspection</li>
+              <li> assessment of its current strengths and weaknesses</li>
+              <li>any specific progress made on areas for improvement identified at previous inspections that remain relevant under the current inspection framework <a href="#">Dummy link</a></li>
+            </ul>
           </div>
           <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-            <p class='govuk-body'>You will also need to understand how trainees are taught to promote pupils’ positive behaviour and attitudes, and how special educational needs and disabilities (SEND) is built in throughout the ITE curriculums offered.
+            <p class='govuk-body'>You will also need to understand:
             </p>
             <ul class="govuk-list govuk-list--bullet">
-              <li>text</li>
-              <li>text</li>
+              <li>how trainees are taught to encourage positive behaviour and attitudes in pupils</li>
+              <li>how those with special educational needs and disabilities (SEND) are supported throughout the ITE curriculums offered.</li>
             </ul>
           </div>
         </div>

--- a/app/views/lead-inspector/confirm-planning-call.html
+++ b/app/views/lead-inspector/confirm-planning-call.html
@@ -64,16 +64,32 @@
           <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
             <p class='govuk-body'>After the ISA notifies the partnership about the upcoming inspection, it is the Lead Inspector's duty to hold a planning call with them. There are two things you need to go through with the partnership:</p>
             <ul class="govuk-list govuk-list--bullet">
-                <li>education focused conversation</li>
-                <li>inspection planning conversation</li>
-              </ul>
+              <li>education focused conversation</li>
+              <li>inspection planning conversation</li>
+            </ul>
+          </div>
+        </div>
+        <div class="govuk-accordion__section ">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading">
+              <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+                1. Inspection planning discussion
+              </span>
+            </h2>
+          </div>
+          <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+            <p class='govuk-body'>On the call, you will review details of trainees’ placements or place of work, including addresses and unique reference numbers (URNs) for schools, colleges and/or settings. This is also your chance to discuss trainee visits and meetings to support exploration of the training course. </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>text</li>
+              <li>text</li>
+            </ul>
           </div>
         </div>
         <div class="govuk-accordion__section ">
           <div class="govuk-accordion__section-header">
             <h2 class="govuk-accordion__section-heading">
               <span class="govuk-accordion__section-button" id="accordion-default-heading-2">
-                1. Educationally focused conversation
+                2. Educationally focused conversation
               </span>
             </h2>
           </div>
@@ -81,19 +97,12 @@
             <p class='govuk-body'>As Lead Inspector, you need to understand the partnership’s context, and assess the progress it has made since the previous inspection, including assessment of its current strengths and weaknesses, and any specific progress made on areas for improvement identified at previous inspections that remain relevant under the current inspection framework.</p>
           </div>
           <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-            <p class='govuk-body'>You will also need to understand how trainees are taught to promote pupils’ positive behaviour and attitudes, and how special educational needs and disabilities (SEND) is built in throughout the ITE curriculums offered.</p>
-          </div>
-        </div>
-        <div class="govuk-accordion__section ">
-          <div class="govuk-accordion__section-header">
-            <h2 class="govuk-accordion__section-heading">
-              <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
-                2. Inspection planning discussion
-              </span>
-            </h2>
-          </div>
-          <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
-            <p class='govuk-body'>On the call, you will review details of trainees’ placements or place of work, including addresses and unique reference numbers (URNs) for schools, colleges and/or settings. This is also your chance to discuss trainee visits and meetings to support exploration of the training course. </p>
+            <p class='govuk-body'>You will also need to understand how trainees are taught to promote pupils’ positive behaviour and attitudes, and how special educational needs and disabilities (SEND) is built in throughout the ITE curriculums offered.
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>text</li>
+              <li>text</li>
+            </ul>
           </div>
         </div>
       </div><!-- end of accordion -->


### PR DESCRIPTION
## Trello card URL:
https://trello.com/c/3zI0Sz3J/63-lis-call-to-ite-partnership-page-improvements

## Changes in this PR:
Re-ordered the accordion list and applied the latest iteration of the content design 
I've added dummy link text and bullet point lists so that when they contact design has been finalised it can easily be applied to the mark up.

## Screenshots of UI changes:
<img width="876" alt="Screenshot 2020-02-12 at 10 16 39" src="https://user-images.githubusercontent.com/10596845/74325593-cab16f00-4d80-11ea-961b-835b33413278.png">
