### PR TITLE
Feature/119-create-a-start-page-shows-both-li-and-isa-journey

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -16,7 +16,7 @@
         Sign in to manage your Ofsted inspections
       </h1>
 
-      <form action="lead-inspector/dashboard" method="post" class="form">
+      <form action="/start" method="post" class="form">
 
         {{ govukInput({
           label: {

--- a/app/views/inspection-support-administrator/dashboard.html
+++ b/app/views/inspection-support-administrator/dashboard.html
@@ -1,0 +1,24 @@
+
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Your dashboard - {{ serviceName }}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+
+      {% if data["uploadDraftInspectionReportForQa"] %}
+        <p class="alert"><strong>ACTION REQUIRED:</strong> <a href="respond-to-comments">Inspection 12345: Respond to comments received after quality assurance</a></p>
+      {% endif %}
+
+      <h1 class="govuk-heading-xl">
+        Your dashboard
+      </h1>
+
+    </div>
+</div>
+
+{% endblock %}

--- a/app/views/start.html
+++ b/app/views/start.html
@@ -1,0 +1,42 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Start page example
+{% endblock %}
+
+{% block header %}
+  <!-- Blank header with no service name for the start page -->
+  {{ govukHeader() }}
+{% endblock %}
+
+{% block beforeContent %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        {% if serviceName %} {{ serviceName }} {% endif %}
+      </h1>
+
+      <ul class="govuk-list">
+        <li>View the Inspection Support Administrator's dashboard</li>
+        <a href="inspection-support-administrator/dashboard" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+            Inspection Support Administrator's dashboard
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+            </svg>
+          </a>
+        <li>View the Lead Inspector's dashboard</li>
+        <a href="lead-inspector/dashboard" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
+            Lead Inspector's dashboard
+            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+            </svg>
+          </a>
+      </ul>
+    </div>
+
+  </div>
+{% endblock %}


### PR DESCRIPTION
Start page to show different journeys and roles available in the same prototype. 
For example ISA and LI journey in the prototype

<img width="1162" alt="Screenshot 2020-02-25 at 14 55 10" src="https://user-images.githubusercontent.com/10596845/75258758-dc623000-57de-11ea-8cfe-672b949e23d6.png">
